### PR TITLE
Allow changes to the cache base directory

### DIFF
--- a/pyembedpg.py
+++ b/pyembedpg.py
@@ -48,10 +48,13 @@ class PyEmbedPg(object):
         Initialize a new Postgres object
         :param version: version to use. If it is not set, use the latest version in .pyembedpg directory. If not present
                         use the latest version remotely. Use 'local' to use the local postgres version installed on the machine
+        :param cache_base_dir: base directory path to save the cache files. If not present, the home directory is used.
         :return:
         """
-        home_dir = expanduser("~")
-        self._cache_dir = os.path.join(home_dir, PyEmbedPg.CACHE_DIRECTORY)
+        if not cache_base_dir:
+            cache_base_dir = expanduser("~")
+
+        self._cache_dir = os.path.join(cache_base_dir, PyEmbedPg.CACHE_DIRECTORY)
 
         # if version is not specified, check local last version otherwise get last remote version
         self.version = version


### PR DESCRIPTION
I need to run the test on a server shared by the developers. When the project maintenance is finished, the project directory is removed from the server.
I would like to be able to save PostgreSQL binaries in the project directory, because if the PostgreSQL binaries are saved in the home directory, it is not clear which project the files are used in.

This commit allows the cache directory to be changed.